### PR TITLE
ACG-403 Add try except to get_soap_cache_file

### DIFF
--- a/FuelSDK/client.py
+++ b/FuelSDK/client.py
@@ -361,10 +361,13 @@ class ET_Client(object):
 
     def get_soap_cache_file(self):
         json_data = {}
-        if os.path.isfile(self.soap_cache_file):
-            file = open(self.soap_cache_file, "r")
-            json_data = json.load(file)
-            file.close()
+        try:
+            if os.path.isfile(self.soap_cache_file):
+                file = open(self.soap_cache_file, "r")
+                json_data = json.load(file)
+                file.close()
+        except Exception:
+            return json_data
 
         return json_data
 


### PR DESCRIPTION
### Description
In order to avoid logged errors within the suds client library we need to use another Fuel SDK which uses the suds client new version mantained by the community which does not have the logger issue. Due to this we are going to move to this fork of Fuel which uses the community suds library. This PR adds the fix with the cached issue to the new fork.